### PR TITLE
Dev

### DIFF
--- a/src/Aspirecafe/Aspirecafe.Baristaapi/Aspirecafe.Baristaapi.csproj
+++ b/src/Aspirecafe/Aspirecafe.Baristaapi/Aspirecafe.Baristaapi.csproj
@@ -1,22 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <UserSecretsId>593b2c20-4237-4e42-9cb4-5f1df8c8b4f8</UserSecretsId>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<UserSecretsId>593b2c20-4237-4e42-9cb4-5f1df8c8b4f8</UserSecretsId>
+		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+		<PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="9.2.1" />
+		<PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="9.2.1" />
+		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="9.2.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\AspireCafe.BaristaApiDomainLayer\AspireCafe.BaristaApiDomainLayer.csproj" />
-    <ProjectReference Include="..\AspireCafe.ServiceDefaults\AspireCafe.ServiceDefaults.csproj" />
-    <ProjectReference Include="..\AspireCafe.Shared\AspireCafe.Shared.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\AspireCafe.BaristaApiDomainLayer\AspireCafe.BaristaApiDomainLayer.csproj" />
+		<ProjectReference Include="..\AspireCafe.ServiceDefaults\AspireCafe.ServiceDefaults.csproj" />
+		<ProjectReference Include="..\AspireCafe.Shared\AspireCafe.Shared.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Aspirecafe/Aspirecafe.Baristaapi/Program.cs
+++ b/src/Aspirecafe/Aspirecafe.Baristaapi/Program.cs
@@ -30,8 +30,8 @@ void AddRouteConstraints(WebApplicationBuilder builder)
 {
     builder.Services.Configure<RouteOptions>(options =>
     {
-        options.ConstraintMap.Add("OrderProcessStation", typeof(OrderProcessStation));
-        options.ConstraintMap.Add("OrderProcessStatus", typeof(OrderProcessStatus));
+        options.ConstraintMap.Add("OrderProcessStation", typeof(OrderProcessStationRouteConstraint));
+        options.ConstraintMap.Add("OrderProcessStatus", typeof(OrderProcessStatusRouteConstraint));
     });
 }
 

--- a/src/Aspirecafe/Aspirecafe.Baristaapi/Program.cs
+++ b/src/Aspirecafe/Aspirecafe.Baristaapi/Program.cs
@@ -1,7 +1,11 @@
 using AspireCafe.BaristaApiDomainLayer.Business;
 using AspireCafe.BaristaApiDomainLayer.Data;
 using AspireCafe.BaristaApiDomainLayer.Facade;
+using AspireCafe.BaristaApiDomainLayer.Managers.Context;
+using AspireCafe.Shared.Enums;
 using AspireCafe.Shared.Extensions;
+using AspireCafe.Shared.Middleware;
+using Microsoft.TeamFoundation.TestManagement.WebApi;
 
 var builder = WebApplication.CreateBuilder(args);
 SetUpBuilder(builder);
@@ -14,11 +18,21 @@ void SetUpBuilder(WebApplicationBuilder builder)
     builder.AddServiceDefaults();
     AddDatabases(builder); //service based configuration - shouldn't be loaded in a shared extension method
     AddScopes(builder); //service based configuration - shouldn't be loaded in a shared extension method
-    AddFluentValidation(builder); //service based configuration - shouldn't be loaded in a shared extension method
     builder.AddVersioning(1);
     builder.AddExceptionHandling();
     builder.AddUniversalConfigurations();
     builder.AddSeq(); //if you choose to opt in to save your traces
+    AddServiceBus(builder);
+    AddRouteConstraints(builder);
+}
+
+void AddRouteConstraints(WebApplicationBuilder builder)
+{
+    builder.Services.Configure<RouteOptions>(options =>
+    {
+        options.ConstraintMap.Add("OrderProcessStation", typeof(OrderProcessStation));
+        options.ConstraintMap.Add("OrderProcessStatus", typeof(OrderProcessStatus));
+    });
 }
 
 void SetUpApp(WebApplication app)
@@ -30,9 +44,16 @@ void SetUpApp(WebApplication app)
     }
     app.ConfigureApplicationDefaults();
 }
+
+void AddServiceBus(WebApplicationBuilder builder)
+{
+    builder.AddAzureServiceBusClient("serviceBusConnection");
+
+}
+
 void AddDatabases(WebApplicationBuilder builder)
 {
-    
+    builder.AddCosmosDbContext<BaristaContext>("aspireCafe", "AspireCafe");
 }
 
 void AddScopes(WebApplicationBuilder builder)
@@ -42,9 +63,5 @@ void AddScopes(WebApplicationBuilder builder)
     builder.Services.AddScoped<IData, Data>();
 }
 
-void AddFluentValidation(WebApplicationBuilder builder)
-{
-    //builder.Services.AddValidatorsFromAssemblyContaining<OrderViewModelValidator>();
-}
 
 

--- a/src/Aspirecafe/Aspirecafe.Counterapi/Program.cs
+++ b/src/Aspirecafe/Aspirecafe.Counterapi/Program.cs
@@ -47,7 +47,7 @@ void AddServiceBus(WebApplicationBuilder builder)
 void AddHttpClient(WebApplicationBuilder builder)
 {
     builder.Services.AddRefitClient<IProductHttpClient>()
-        .ConfigureHttpClient(c => c.BaseAddress = new Uri(builder.Configuration["productApi"]));
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri(builder.Configuration["productApi"] ?? ""));
 }
 
 void AddDatabases(WebApplicationBuilder builder)

--- a/src/Aspirecafe/Aspirecafe.Kitchenapi/Aspirecafe.Kitchenapi.csproj
+++ b/src/Aspirecafe/Aspirecafe.Kitchenapi/Aspirecafe.Kitchenapi.csproj
@@ -1,22 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <UserSecretsId>8ef0e774-a3fc-4458-819c-de45803f2def</UserSecretsId>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<UserSecretsId>8ef0e774-a3fc-4458-819c-de45803f2def</UserSecretsId>
+		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+		<PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="9.2.1" />
+		<PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="9.2.1" />
+		<PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="9.2.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\AspireCafe.KitchenApiDomainLayer\AspireCafe.KitchenApiDomainLayer.csproj" />
-    <ProjectReference Include="..\AspireCafe.ServiceDefaults\AspireCafe.ServiceDefaults.csproj" />
-    <ProjectReference Include="..\AspireCafe.Shared\AspireCafe.Shared.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\AspireCafe.KitchenApiDomainLayer\AspireCafe.KitchenApiDomainLayer.csproj" />
+		<ProjectReference Include="..\AspireCafe.ServiceDefaults\AspireCafe.ServiceDefaults.csproj" />
+		<ProjectReference Include="..\AspireCafe.Shared\AspireCafe.Shared.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Aspirecafe/Aspirecafe.Kitchenapi/Controllers/OrderController.cs
+++ b/src/Aspirecafe/Aspirecafe.Kitchenapi/Controllers/OrderController.cs
@@ -1,9 +1,9 @@
-﻿using AspireCafe.BaristaApiDomainLayer.Facade;
+﻿using AspireCafe.KitchenApiDomainLayer.Facade;
+using AspireCafe.Shared.Enums;
+using AspireCafe.Shared.Extensions;
 using AspireCafe.Shared.Models.Service.OrderUpdate;
 using AspireCafe.Shared.Results;
 using Microsoft.AspNetCore.Mvc;
-using AspireCafe.Shared.Extensions;
-using AspireCafe.Shared.Enums;
 
 namespace AspireCafe.KitchenApi.Controllers
 {

--- a/src/Aspirecafe/Aspirecafe.Kitchenapi/Program.cs
+++ b/src/Aspirecafe/Aspirecafe.Kitchenapi/Program.cs
@@ -1,7 +1,10 @@
-using AspireCafe.BaristaApiDomainLayer.Facade;
 using AspireCafe.KitchenApiDomainLayer.Business;
 using AspireCafe.KitchenApiDomainLayer.Data;
+using AspireCafe.KitchenApiDomainLayer.Facade;
+using AspireCafe.KitchenApiDomainLayer.Managers.Context;
+using AspireCafe.Shared.Enums;
 using AspireCafe.Shared.Extensions;
+using AspireCafe.Shared.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 SetUpBuilder(builder);
@@ -14,11 +17,21 @@ void SetUpBuilder(WebApplicationBuilder builder)
     builder.AddServiceDefaults();
     AddDatabases(builder); //service based configuration - shouldn't be loaded in a shared extension method
     AddScopes(builder); //service based configuration - shouldn't be loaded in a shared extension method
-    AddFluentValidation(builder); //service based configuration - shouldn't be loaded in a shared extension method
     builder.AddVersioning(1);
     builder.AddExceptionHandling();
     builder.AddUniversalConfigurations();
     builder.AddSeq(); //if you choose to opt in to save your traces
+    AddServiceBus(builder);
+    AddRouteConstraints(builder);
+}
+
+void AddRouteConstraints(WebApplicationBuilder builder)
+{
+    builder.Services.Configure<RouteOptions>(options =>
+    {
+        options.ConstraintMap.Add("OrderProcessStation", typeof(OrderProcessStation));
+        options.ConstraintMap.Add("OrderProcessStatus", typeof(OrderProcessStatus));
+    });
 }
 
 void SetUpApp(WebApplication app)
@@ -30,8 +43,16 @@ void SetUpApp(WebApplication app)
     }
     app.ConfigureApplicationDefaults();
 }
+
+void AddServiceBus(WebApplicationBuilder builder)
+{
+    builder.AddAzureServiceBusClient("serviceBusConnection");
+
+}
+
 void AddDatabases(WebApplicationBuilder builder)
 {
+    builder.AddCosmosDbContext<KitchenContext>("aspireCafe", "AspireCafe");
 }
 
 void AddScopes(WebApplicationBuilder builder)
@@ -41,9 +62,5 @@ void AddScopes(WebApplicationBuilder builder)
     builder.Services.AddScoped<IData, Data>();
 }
 
-void AddFluentValidation(WebApplicationBuilder builder)
-{
-    
-}
 
 

--- a/src/Aspirecafe/Aspirecafe.Kitchenapi/Program.cs
+++ b/src/Aspirecafe/Aspirecafe.Kitchenapi/Program.cs
@@ -29,8 +29,8 @@ void AddRouteConstraints(WebApplicationBuilder builder)
 {
     builder.Services.Configure<RouteOptions>(options =>
     {
-        options.ConstraintMap.Add("OrderProcessStation", typeof(OrderProcessStation));
-        options.ConstraintMap.Add("OrderProcessStatus", typeof(OrderProcessStatus));
+        options.ConstraintMap.Add("OrderProcessStation", typeof(OrderProcessStationRouteConstraint));
+        options.ConstraintMap.Add("OrderProcessStatus", typeof(OrderProcessStatusRouteConstraint));
     });
 }
 

--- a/src/Aspirecafe/Aspirecafe.Kitchenapidomainlayer/Facade/Facade.cs
+++ b/src/Aspirecafe/Aspirecafe.Kitchenapidomainlayer/Facade/Facade.cs
@@ -4,7 +4,7 @@ using AspireCafe.Shared.Models.Domain.Orders;
 using AspireCafe.Shared.Models.Service.OrderUpdate;
 using AspireCafe.Shared.Results;
 
-namespace AspireCafe.BaristaApiDomainLayer.Facade
+namespace AspireCafe.KitchenApiDomainLayer.Facade
 {
     public class Facade : IFacade
     {

--- a/src/Aspirecafe/Aspirecafe.Kitchenapidomainlayer/Facade/IFacade.cs
+++ b/src/Aspirecafe/Aspirecafe.Kitchenapidomainlayer/Facade/IFacade.cs
@@ -3,7 +3,7 @@ using AspireCafe.Shared.Models.Domain.Orders;
 using AspireCafe.Shared.Models.Service.OrderUpdate;
 using AspireCafe.Shared.Results;
 
-namespace AspireCafe.BaristaApiDomainLayer.Facade
+namespace AspireCafe.KitchenApiDomainLayer.Facade
 {
     public interface IFacade
     {

--- a/src/Aspirecafe/Aspirecafe.Shared/Enums/Enumerations.cs
+++ b/src/Aspirecafe/Aspirecafe.Shared/Enums/Enumerations.cs
@@ -1,4 +1,6 @@
-﻿namespace AspireCafe.Shared.Enums
+﻿using Microsoft.AspNetCore.Routing;
+
+namespace AspireCafe.Shared.Enums
 {
     public enum DocumentType
     {

--- a/src/Aspirecafe/Aspirecafe.Shared/Middleware/EnumerationRouteConstraints.cs
+++ b/src/Aspirecafe/Aspirecafe.Shared/Middleware/EnumerationRouteConstraints.cs
@@ -1,0 +1,25 @@
+﻿using AspireCafe.Shared.Enums;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace AspireCafe.Shared.Middleware
+{
+    public class OrderProcessStationRouteConstraint : IRouteConstraint, IParameterPolicy
+    {
+        public bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
+        {
+            var candidate = values[routeKey]?.ToString();
+            return System.Enum.TryParse(candidate, out OrderProcessStation result);
+        }
+    }
+
+    public class OrderProcessStatusRouteConstraint : IRouteConstraint, IParameterPolicy
+    {
+        public bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
+        {
+            var candidate = values[routeKey]?.ToString();
+            return System.Enum.TryParse(candidate, out OrderProcessStatus result);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several changes to enhance the AspireCafe microservices, including new dependencies, configuration updates, and the introduction of route constraints. The changes primarily focus on improving service bus integration, Cosmos DB support, and route constraint handling for both the Barista and Kitchen APIs.

### Dependency and Configuration Updates:
* Added new package references for `Aspire.Azure.Messaging.ServiceBus`, `Aspire.Microsoft.Azure.Cosmos`, and `Aspire.Microsoft.EntityFrameworkCore.Cosmos` in both `Aspirecafe.Baristaapi.csproj` and `Aspirecafe.Kitchenapi.csproj` to support service bus and Cosmos DB integration. [[1]](diffhunk://#diff-b910d2bb6ccdb6ed80432da8f1d0023b68925b3909ad01929a4459ef90120ec5R14-R16) [[2]](diffhunk://#diff-4e91945f394ebf0d53724bf12b0a4e662417eeb028de3959857ffcf1e64d59d6R14-R16)

### Service Bus and Cosmos DB Integration:
* Introduced `AddServiceBus` and `AddDatabases` methods in `Program.cs` for both Barista and Kitchen APIs to configure Azure Service Bus and Cosmos DB contexts. [[1]](diffhunk://#diff-99cc8932a40901a0bc88140ed963f1a6cedc10f44edca6f060ca3cb0619dbeb0L33-L48) [[2]](diffhunk://#diff-21bd1a4dd31e9281d6a8affa1a8dc1bbdb8418e9030b123d9d53806f57577d5eR46-R55)

### Route Constraints:
* Implemented `OrderProcessStationRouteConstraint` and `OrderProcessStatusRouteConstraint` in `EnumerationRouteConstraints.cs` to validate route parameters against enumerations.
* Added `AddRouteConstraints` method in `Program.cs` for both Barista and Kitchen APIs to register these route constraints. [[1]](diffhunk://#diff-99cc8932a40901a0bc88140ed963f1a6cedc10f44edca6f060ca3cb0619dbeb0L17-R35) [[2]](diffhunk://#diff-21bd1a4dd31e9281d6a8affa1a8dc1bbdb8418e9030b123d9d53806f57577d5eL17-R34)

### Namespace Adjustments:
* Updated namespaces in the Kitchen API to replace references to `BaristaApiDomainLayer` with `KitchenApiDomainLayer` for better modularity and clarity. [[1]](diffhunk://#diff-e27101b3e657982602441588d2ed32c17f3f311e17d9f30bfc8df0ce14a84df1L1-L6) [[2]](diffhunk://#diff-140decf19bba7d34067542f411d39d7296c3600cfcb1d018018a9a2cff22c645L7-R7) [[3]](diffhunk://#diff-02837c1ddd86b08ce38bb7d191810644800f3e52038b012c32097bc207844bd2L6-R6)

### Minor Fixes:
* Adjusted `ConfigureHttpClient` in `Aspirecafe.Counterapi` to handle null `productApi` configuration values gracefully.